### PR TITLE
Delete destination page cache for moved media

### DIFF
--- a/src/gallery/index.py
+++ b/src/gallery/index.py
@@ -140,7 +140,7 @@ class Indexer:
         docs = [
             self.index_metadata(path, meta=meta)
         ]
-        async for ok, result in async_streaming_bulk(client=self.es, actions=docs, chunk_size=1000, max_retries=2, yield_ok=False, request_timeout=60):
+        async for ok, result in async_streaming_bulk(client=self.es, actions=docs, chunk_size=1000, max_retries=2, yield_ok=False, request_timeout=1):
             action, result = result.popitem()
             if not ok:
                 logging.warning('failed to process: %r', result)
@@ -151,7 +151,7 @@ class Indexer:
         root_path = ENV.SOURCE
         doc_path = str(path.relative_to(root_path))
         id_ = hashlib.sha1(doc_path.encode('utf8')).hexdigest()
-        await self.es.delete(index=self.index_name, id=id_, timeout=60)
+        await self.es.delete(index=self.index_name, id=id_, timeout='1s')
 
     async def search(self, query, limit=100):
         return await self.es.search(index=self.es_index, body={

--- a/src/gallery/server.py
+++ b/src/gallery/server.py
@@ -330,6 +330,12 @@ class EditHandler(BaseHandler):
             web_path = Path('/edit') / new_media_path.relative_to(basedir)
             self.redirect(str(web_path))
             ret = False
+
+            path = str(new_media_path.parent.relative_to(ENV.SOURCE)).strip('/')
+            try:
+                await self.page_cache.delete(path)
+            except Exception as e:
+                logging.info('error removing %s from cache: %r', path, e)
         else:
             meta['title'] = self.get_argument('title')
             meta['summary'] = self.get_argument('summary')


### PR DESCRIPTION
Delete destination page cache for moved media.

Also, fix ES timeout values to be short when inside a live web request.