### PR TITLE
add version string to all _src media to fix browser caching

### DIFF
--- a/src/gallery/config.py
+++ b/src/gallery/config.py
@@ -28,6 +28,9 @@ class EnvConfig:
     CI_TEST: bool = False
     LOG_LEVEL: str = 'INFO'
 
+    VERSION_HASH_DIGEST_SIZE: int = 20
+    VERSION_HASH_PERSON: bytes = b'GalleryVersion'
+
     def __post_init__(self) -> None:
         object.__setattr__(self, 'LOG_LEVEL', self.LOG_LEVEL.upper())  # b/c frozen
 

--- a/src/gallery/data/theme/templates/album.html
+++ b/src/gallery/data/theme/templates/album.html
@@ -22,7 +22,7 @@
     {% for alb in album.albums %}
       <div id="{{ alb.name }}" class="menu-img thumbnail">
         <a href="{{ alb.meta.get('link', alb.url) }}">
-          <img src="{{ alb.thumbnail }}" class="album_thumb"
+          <img src="{{ version_hash(alb.thumbnail) }}" class="album_thumb"
                alt="{{ alb.meta['title'] }}" title="{{ alb.meta['title'] }}" /></a>
         <div class="caption">
           <span class="title">{{ alb.meta['title'] }}</span>
@@ -39,10 +39,10 @@
     {% for image in album.images %}
       <figure id="{{ image.name }}" class="gallery__img--secondary thumbnail"
               itemprop="associatedMedia" itemscope itemtype="http://schema.org/ImageObject"
-              data-orig="{{ image.url }}">
-        <a href="{{ image.url }}" itemprop="contentUrl" data-size="{{image.width}}x{{image.height}}">
+              data-orig="{{ version_hash(image.url) }}">
+        <a href="{{ version_hash(image.url) }}" itemprop="contentUrl" data-size="{{image.width}}x{{image.height}}">
           <img src="{{ template_url }}/echo/blank.gif"
-                data-echo="{{ image.thumbnail }}"
+                data-echo="{{ version_hash(image.thumbnail) }}"
                 alt="{{ image.url }}" itemprop="thumbnail" title="{{ image.meta['title'] }}" />
         </a>
         <div class="lightbox_caption" itemprop="caption description">{{ image.meta['title'] }}{% if image.meta['summary'] %}<br>{{ image.meta['summary'] }}{% end %}<br>{{ image.meta['description'] }}</div>
@@ -59,13 +59,13 @@
       <figure id="{{ video.name }}" class="gallery__img--secondary thumbnail video"
               itemprop="associatedMedia" itemscope itemtype="http://schema.org/ImageObject"
               data-orig="{{ video.url }}">
-        <a href="{{ video.url }}" itemprop="contentUrl" data-type="video"
-            data-video='<div class="video"><div class="video__container"><video controls><source src="{{ video.url }}" type="{{ video.mime }}" /></video></div></div>'>
+        <a href="{{ version_hash(video.url) }}" itemprop="contentUrl" data-type="video"
+            data-video='<div class="video"><div class="video__container"><video controls><source src="{{ version_hash(video.url) }}" type="{{ video.mime }}" /></video></div></div>'>
         <div class="video-overlay">
           <span class="material-icons">play_circle_outline</span>
         </div>
         <img src="{{ template_url }}/echo/blank.gif"
-              data-echo="{{ video.thumbnail }}"
+              data-echo="{{ version_hash(video.thumbnail) }}"
               alt="{{ video.thumbnail }}" itemprop="thumbnail" title="" />
         </a>
         <div class="lightbox_caption" itemprop="caption description">{{ video.meta['title'] }}<br>{{ video.meta['description'] }}</div>
@@ -82,7 +82,7 @@
       <figure id="{{ file.name }}" class="gallery__img--secondary thumbnail file">
         <a href="{{ file.url }}" target="_blank">
         <img src="{{ template_url }}/echo/blank.gif"
-              data-echo="{{ file.thumbnail }}"
+              data-echo="{{ version_hash(file.thumbnail) }}"
               alt="{{ file.thumbnail }}" itemprop="thumbnail" title="" />
         </a>
         <div class="lightbox_caption" itemprop="caption description">{{ file.meta['title'] }}<br>{{ file.meta['description'] }}</div>

--- a/src/gallery/data/theme/templates/base.html
+++ b/src/gallery/data/theme/templates/base.html
@@ -21,9 +21,9 @@
     <meta name="description" content="IceCube Gallery">
     {% end %}
     {% if album and album.thumbnail %}
-    <meta property="og:image" content="{{ album.thumbnail }}"/>
+    <meta property="og:image" content="{{ version_hash(album.thumbnail) }}"/>
     {% elif media and media.thumbnail %}
-    <meta property="og:image" content="{{ media.thumbnail }}"/>
+    <meta property="og:image" content="{{ version_hash(media.thumbnail) }}"/>
     {% end %}
     <link rel="stylesheet" href="{{ template_url }}/styles.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/src/gallery/data/theme/templates/search.html
+++ b/src/gallery/data/theme/templates/search.html
@@ -28,8 +28,8 @@
     {% for ret in results %}
     <div class="search-result">
       <div class="thumbnail">
-        <a href="{{ ret.url }}">
-          <img src="{{ ret.thumbnail }}" />
+        <a href="{{ version_hash(ret.url) }}">
+          <img src="{{ version_hash(ret.thumbnail) }}" />
         </a>
       </div>
       <div class="details">
@@ -47,7 +47,7 @@
         {% if ret.type == "album" %}
         <div><span class="label">Url: </span><a href="{{ ret.url }}"><span class="orig">{{ ret.url }}</span></a></div>
         {% else %}
-        <div><span class="label">File: </span><a href="{{ ret.src }}"><span class="orig">{{ ret.src }}</span></a></div>
+        <div><span class="label">File: </span><a href="{{ version_hash(ret.src) }}"><span class="orig">{{ ret.src }}</span></a></div>
         <div><span class="label">Album: </span><a href="{{ ret.album_url }}"><span class="orig">{{ ret.album_url }}</span></a></div>
         {% end %}
       </div>


### PR DESCRIPTION
The browser is caching media from nginx, which is a problem when updating a file with the same name (such as thumb.jpg).

Uses blake2b to add a version hash to all /_src/ media.